### PR TITLE
cmake build system for shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ set (SOURCES	rar/uncompress-rar.c
 			zip/uncompress-zip.c
 			tar/tar.c
 			tar/parse-tar.c
-			main.c
 			lzmasdk/Ppmd7.c
 			lzmasdk/Ppmd8.c
 			lzmasdk/CpuArch.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 2.6)
+project(unarr)
+
+set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+#set build type to default if unset
+if( NOT CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING
+       "Choose the type of build, options are: None Debug Release RelWithDebInfo
+MinSizeRel."
+       FORCE )
+endif()
+
+find_package(ZLIB)
+find_package(BZip2)
+find_package(Threads)
+
+if (UNIX OR MINGW)
+    add_compile_options(-std=c99 -fomit-frame-pointer)
+endif (UNIX OR MINGW)
+
+include_directories(common rar tar zip _7z)
+
+set (HEADERS 	common/allocator.h
+			common/unarr-imp.h
+			rar/rar.h
+			rar/lzss.h
+			rar/rarvm.h
+			lzmasdk/LzmaDec.h
+			lzmasdk/Ppmd7.h
+			lzmasdk/CpuArch.h
+			lzmasdk/Ppmd.h
+			lzmasdk/Types.h
+			lzmasdk/Ppmd8.h
+			_7z/_7z.h
+			zip/zip.h
+			zip/inflate.h
+			tar/tar.h)
+
+set (SOURCES	rar/uncompress-rar.c
+			rar/huffman-rar.c
+			rar/rar.c
+			rar/filter-rar.c
+			rar/rarvm.c
+			rar/parse-rar.c
+			_7z/_7z.c
+			zip/zip.c
+			zip/inflate.c
+			zip/parse-zip.c
+			zip/uncompress-zip.c
+			tar/tar.c
+			tar/parse-tar.c
+			main.c
+			lzmasdk/Ppmd7.c
+			lzmasdk/Ppmd8.c
+			lzmasdk/CpuArch.c
+			lzmasdk/LzmaDec.c
+			lzmasdk/Ppmd7Dec.c
+			lzmasdk/Ppmd8Dec.c
+			common/custalloc.c
+			common/unarr.c
+			common/stream.c
+			common/conv.c
+			common/crc32.c
+			)
+
+add_library(unarr SHARED unarr.h ${HEADERS} ${SOURCES})
+if (UNIX)
+    target_link_libraries(unarr m)
+endif (UNIX)
+
+if (Threads_FOUND)
+    target_link_libraries(unarr ${CMAKE_THREAD_LIBS_INIT})
+endif (Threads_FOUND)
+
+if (ZLIB_FOUND)
+    include_directories(${ZLIB_INCLUDE_DIRS})
+    target_link_libraries(unarr ${ZLIB_LIBRARIES})
+    add_definitions(-DHAVE_ZLIB)
+endif(ZLIB_FOUND)
+
+if (BZIP2_FOUND)
+    include_directories(${BZIP_INCLUDE_DIRS})
+    target_link_libraries (unarr ${BZIP2_LIBRARIES})
+    add_definitions(-DHAVE_BZIP2)
+endif (BZIP2_FOUND)
+
+install(TARGETS unarr DESTINATION lib)
+install(FILES unarr.h DESTINATION include)


### PR DESCRIPTION
Hi Zeniko,

this is my take on a cmake based build system for unarr. It builds and installs unarr as a shared library on Linux and is probably usable on mac and win as well. It's written with packageability for Linux in mind and will detect and make use of the systems zlib and bzip2 installations. I'd be glad if you could take a look at it and maybe adapt it. Tell me if you need any modifications ;)

Regards,

selmf
